### PR TITLE
Only run documentation builds when needed

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'documentation/**/*'
 
 permissions:
   contents: write


### PR DESCRIPTION
To avoid unnecessary CI run.