### PR TITLE
Allow to customize Grafana using environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Makes it possible to [customize Grafana](https://hendric-dev.github.io/k8s-observability/configuration-reference/grafana.html#customize-grafana) further, using environment varaibles.
+| [#11](https://github.com/hendric-dev/k8s-observability/issues/11)
 
 ## [0.2.0] - 2022-08-15
 ### Added

--- a/documentation/docs/configuration-reference/grafana.md
+++ b/documentation/docs/configuration-reference/grafana.md
@@ -16,6 +16,7 @@ All Grafana config is stored under the **grafana** object in the config.
       ingress: {},
       pod: {},
     },
+    env:: {},
     host:: 'grafana.my-server.com',
     image:: 'grafana/grafana:9.0.5',
     labels:: {
@@ -48,6 +49,7 @@ All Grafana config is stored under the **grafana** object in the config.
 | `annotations.deployment` | Annotations added at the deployment (topmost) level. <br> `{}` |
 | `annotations.ingress` | Annotations added to the ingress. <br> `{}` |
 | `annotations.pod` | Annotations added at the pod level. <br> `{}` |
+| `env` | Environment variables that are added to the Grafana container. See [Customize Grafana](#customize-grafana) <br> `{}` |
 | `host` | Hostname where the UI is exposed. <br> `grafana.my-server.com` |
 | `image` | Docker image that gets deployed. <br> `grafana/grafana:9.0.5` |
 | `labels.deployment` | Labels added at the deployment (topmost) level. <br> `{}` |
@@ -63,3 +65,25 @@ All Grafana config is stored under the **grafana** object in the config.
 | `resources.memory.limit` | Max. allowed amount of memory. <br> `128Mi` |
 | `secrets.admin.username` | Admin username for Grafana. <br> `<fill with admin username>` |
 | `secrets.admin.password` | Admin password for Grafana. <br> `<fill with admin password>` |
+
+## Customize Grafana
+
+While it is possible to configure the most common options through the Jsonnet config above,
+it doesn't cover all use cases. \
+Grafana itself is quite customizable and allows to set any possible option through environment variables.
+See [overide configuration with environment variabls](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) on the official Grafana documentation.
+
+The environment variables can be set by using the `env` field mentioned above. \
+An example may look like this:
+
+```js
+{
+  grafana+: {
+    env+:: {
+      'GF_AUTH_DISABLE_LOGIN_FORM': true,
+      'GF_AUTH_GITHUB_AUTH_URL': 'https://github.com/login/oauth/authorize',
+      'GF_AUTH_GITHUB_ENABLED': true,
+    },
+  }
+}
+```

--- a/grafana/deployment/kubernetes/deployment.libsonnet
+++ b/grafana/deployment/kubernetes/deployment.libsonnet
@@ -17,7 +17,7 @@
           envVar.fromSecretRef('GF_SECURITY_ADMIN_PASSWORD', this.name, 'admin_password'),
           envVar.fromSecretRef('INFLUX_API_TOKEN', this.name + '-influx-db-token', 'token'),
         ]
-        + [envVar.new(name, this.env[name]) for name in std.objectFields(this.env)],
+        + [envVar.new(name, std.toString(this.env[name])) for name in std.objectFields(this.env)],
       )
       + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
       + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})

--- a/grafana/deployment/kubernetes/deployment.libsonnet
+++ b/grafana/deployment/kubernetes/deployment.libsonnet
@@ -11,11 +11,14 @@
     local this = self,
     container:: container.new(this.name, this.image)
       + container.withPorts([containerPort.newNamed(this.ports.internal, 'http')])
-      + container.withEnv([
-        envVar.fromSecretRef('GF_SECURITY_ADMIN_USER', this.name, 'admin_username'),
-        envVar.fromSecretRef('GF_SECURITY_ADMIN_PASSWORD', this.name, 'admin_password'),
-        envVar.fromSecretRef('INFLUX_API_TOKEN', this.name + '-influx-db-token', 'token'),
-      ])
+      + container.withEnv(
+        [
+          envVar.fromSecretRef('GF_SECURITY_ADMIN_USER', this.name, 'admin_username'),
+          envVar.fromSecretRef('GF_SECURITY_ADMIN_PASSWORD', this.name, 'admin_password'),
+          envVar.fromSecretRef('INFLUX_API_TOKEN', this.name + '-influx-db-token', 'token'),
+        ]
+        + [envVar.new(name, this.env[name]) for name in std.objectFields(this.env)],
+      )
       + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
       + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
       + container.withVolumeMounts([

--- a/grafana/deployment/kubernetes/grafana.libsonnet
+++ b/grafana/deployment/kubernetes/grafana.libsonnet
@@ -6,6 +6,7 @@
       ingress: {},
       pod: {},
     },
+    env:: {},
     host:: 'grafana.my-server.com',
     image:: 'grafana/grafana:9.0.5',
     labels:: {


### PR DESCRIPTION
Resolves #11 

Configuring auth providers is quite diverse depending on the type of authentification.
To avoid compromises this PR makes it possible to configure every single Grafana option by using environment variables. Makes it less comfortable to set up, but gives flexibility for all edge cases.