### PR TITLE
Changed the home dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Get an overview of CPU & memory usage with the new pod dashboards | [#5](https://github.com/hendric-dev/k8s-observability/issues/5)
 - Grafana settings are now persisted over restarts | [#14](https://github.com/hendric-dev/k8s-observability/issues/14)
 
+### Changed
+- Changed the default Grafana home dashboard to the Kubernetes node resources | [#12](https://github.com/hendric-dev/k8s-observability/issues/12)
+
 ## [0.2.0] - 2022-08-15
 ### Added
 - Loki was added to the stack to process Kubernetes logs | [#1](https://github.com/hendric-dev/k8s-observability/issues/1)

--- a/grafana/config/grafana.ini
+++ b/grafana/config/grafana.ini
@@ -1,1 +1,4 @@
 # https://grafana.com/docs/grafana/latest/administration/configuration/
+
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/kubernetes-node-resources.json


### PR DESCRIPTION
For now the Kubernetes node resources is the default dashboard.
Because it provides the best overview about the health of the system.

Resolves #12 