### PR TITLE
Fix the Vector unit test job

### DIFF
--- a/vector/Earthfile
+++ b/vector/Earthfile
@@ -2,7 +2,9 @@ VERSION 0.6
 
 FROM timberio/vector:0.23.0-alpine
 WORKDIR /vector
+
 ENV LOKI_ENDPOINT=https://loki
+ENV VECTOR_INTERNAL_PORT=8686
 
 test:
   COPY . .


### PR DESCRIPTION
It was missing the "VECTOR_INTERNAL_PORT" environment variable. Not setting it makes the config invalid and fails the unit tests.