### PR TITLE
Upgrade image versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## [0.4.0] - 2022-09-13
 ### Added
 - [Tempo](https://github.com/grafana/tempo) is now part of the stack allowing to trace requests | [#24](https://github.com/hendric-dev/k8s-observability/issues/24)
 - Allow to use an external NFS to store Grafana, Loki and InfluxDB data | [#23](https://github.com/hendric-dev/k8s-observability/issues/23)
 - Custom dashboards can now be provisioned | [#25](https://github.com/hendric-dev/k8s-observability/issues/25)
+
+### Changed
+- Updated dependencies to the latest versions
+  - Grafana: `9.0.5` -> `9.1.5`
+  - InfluxDB: `2.2.0-alpine` -> `2.4.0-alpine`
+  - Vector: `0.21.0-alpine` -> `0.24.1-alpine`
 
 ## [0.3.0] - 2022-08-30
 ### Added
@@ -35,7 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Grafana username/password was moved to secrets in the config
 
-[Unreleased]: https://github.com/hendric-dev/k8s-observability/compare/0.3.0...main
+[Unreleased]: https://github.com/hendric-dev/k8s-observability/compare/0.4.0...main
+[0.4.0]: https://github.com/hendric-dev/k8s-observability/releases/tag/0.4.0
 [0.3.0]: https://github.com/hendric-dev/k8s-observability/releases/tag/0.3.0
 [0.2.0]: https://github.com/hendric-dev/k8s-observability/releases/tag/0.2.0
 [0.1.0]: https://github.com/hendric-dev/k8s-observability/releases/tag/0.1.0

--- a/grafana/deployment/kubernetes/grafana.libsonnet
+++ b/grafana/deployment/kubernetes/grafana.libsonnet
@@ -22,7 +22,7 @@
     ],
     env:: {},
     host:: 'grafana.my-server.com',
-    image:: 'grafana/grafana:9.0.5',
+    image:: 'grafana/grafana:9.1.5',
     labels:: {
       deployment: {},
       pod: {},

--- a/influxdb/deployment/kubernetes/influxdb.libsonnet
+++ b/influxdb/deployment/kubernetes/influxdb.libsonnet
@@ -8,7 +8,7 @@
     },
     bucket:: 'metrics',
     host:: 'monitoring.db.my-server.com',
-    image:: 'influxdb:2.2.0-alpine',
+    image:: 'influxdb:2.4.0-alpine',
     labels:: {
       deployment: {},
       pod: {},

--- a/vector/Earthfile
+++ b/vector/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.6
 
-FROM timberio/vector:0.23.0-alpine
+FROM timberio/vector:0.24.1-alpine
 WORKDIR /vector
 
 ENV LOKI_ENDPOINT=https://loki

--- a/vector/deployment/kubernetes/rbac.libsonnet
+++ b/vector/deployment/kubernetes/rbac.libsonnet
@@ -14,7 +14,7 @@ local tk = import 'tk';
       + clusterRole.metadata.withLabels(this.labels.selector)
       + clusterRole.withRules([
         resourceRule.withApiGroups('')
-        + resourceRule.withResources(['pods', 'namespaces', 'nodes/proxy'])
+        + resourceRule.withResources(['pods', 'namespaces', 'nodes', 'nodes/proxy'])
         + resourceRule.withVerbs(['get', 'list', 'watch']),
       ]),
     clusterRoleBinding: clusterRoleBinding.new(this.name)

--- a/vector/deployment/kubernetes/vector.libsonnet
+++ b/vector/deployment/kubernetes/vector.libsonnet
@@ -5,7 +5,7 @@
       deployment: {},
       pod: {},
     },
-    image:: 'timberio/vector:0.21.0-alpine',
+    image:: 'timberio/vector:0.24.1-alpine',
     labels:: {
       deployment: {},
       pod: {},


### PR DESCRIPTION
- Grafana: `9.0.5` -> `9.1.5`
- InfluxDB: `2.2.0-alpine` -> `2.4.0-alpine`
- Vector: `0.21.0-alpine` -> `0.24.1-alpine`