### PR TITLE
Move all k8s resources to the "deployables" namespace

### DIFF
--- a/grafana/deployment/kubernetes/certificate.libsonnet
+++ b/grafana/deployment/kubernetes/certificate.libsonnet
@@ -2,26 +2,28 @@
 {
   grafana+: {
     local this = self,
-    certificate: (
-      if this.security.tls.enabled
-      then {
-        apiVersion: 'cert-manager.io/v1',
-        kind: 'Certificate',
-        metadata: {
-          labels: {
-            'app.kubernetes.io/name': this.name,
+    deployables+: {
+      certificate: (
+        if this.security.tls.enabled
+        then {
+          apiVersion: 'cert-manager.io/v1',
+          kind: 'Certificate',
+          metadata: {
+            labels: {
+              'app.kubernetes.io/name': this.name,
+            },
+            name: this.name,
           },
-          name: this.name,
-        },
-        spec: {
-          secretName: this.name + '-certificate',
-          issuerRef: {
-            name: this.security.tls.issuer,
+          spec: {
+            secretName: this.name + '-certificate',
+            issuerRef: {
+              name: this.security.tls.issuer,
+            },
+            dnsNames: [this.host],
           },
-          dnsNames: [this.host],
-        },
-      }
-      else {}
-    ),
-  }
+        }
+        else {}
+      ),
+    },
+  },
 }

--- a/grafana/deployment/kubernetes/config-map.libsonnet
+++ b/grafana/deployment/kubernetes/config-map.libsonnet
@@ -4,49 +4,50 @@
 
   grafana+: {
     local this = self,
+    deployables+: {
+      local dashboards = [
+        {
+          name: dashboard.title,
+          folder: dashboard.folder,
+          type: 'file',
+          options: {
+            path: '/var/lib/grafana/dashboards/' + dashboard.file,
+          },
+        }
+        for dashboard in this.dashboards
+      ],
 
-    local dashboards = [
-      {
-        name: dashboard.title,
-        folder: dashboard.folder,
-        type: 'file',
-        options: {
-          path: '/var/lib/grafana/dashboards/' + dashboard.file,
+      local datasources = {
+        logs: std.parseYaml(importstr '../../config/datasources/logs.yaml') + {
+          url: 'http://' + $.loki.name + ':' + $.loki.ports.external,
         },
-      }
-      for dashboard in this.dashboards
-    ],
+        metrics: std.parseYaml(importstr '../../config/datasources/metrics.yaml') + {
+          jsonData+: {
+            defaultBucket: $.influxDB.bucket,
+            organization: $.influxDB.organisation,
+          },
+          url: 'http://' + $.influxDB.name + ':' + $.influxDB.ports.external,
+        },
+        traces: std.parseYaml(importstr '../../config/datasources/traces.yaml') + {
+          url: 'http://' + $.tempo.name + ':' + $.tempo.ports.tempo.external,
+        },
+      },
 
-    local datasources = {
-      logs: std.parseYaml(importstr '../../config/datasources/logs.yaml') + {
-        url: 'http://' + $.loki.name + ':' + $.loki.ports.external,
-      },
-      metrics: std.parseYaml(importstr '../../config/datasources/metrics.yaml') + {
-        jsonData+: {
-          defaultBucket: $.influxDB.bucket,
-          organization: $.influxDB.organisation,
-        },
-        url: 'http://' + $.influxDB.name + ':' + $.influxDB.ports.external,
-      },
-      traces: std.parseYaml(importstr '../../config/datasources/traces.yaml') + {
-        url: 'http://' + $.tempo.name + ':' + $.tempo.ports.tempo.external,
+      configMap: {
+        datasources: configMap.new(this.name + '-datasources', {
+          'datasources.yaml': std.manifestYamlDoc({
+            apiVersion: 1,
+            datasources: [datasource for datasource in std.objectValues(datasources)],
+          }),
+        }) + configMap.metadata.withLabels($.grafana.labels.selector),
+        dashboards: configMap.new(this.name + '-dashboards',
+          {'dashboards.yaml': std.manifestYamlDoc({apiVersion: 1, providers: dashboards})}
+          + {[dashboard.file]: dashboard.definition for dashboard in this.dashboards}
+        ) + configMap.metadata.withLabels(this.labels.selector),
+        grafana: configMap.new(this.name, {
+          'grafana.ini': (importstr '../../config/grafana.ini'),
+        }) + configMap.metadata.withLabels(this.labels.selector),
       },
     },
-
-    configMap: {
-      datasources: configMap.new(this.name + '-datasources', {
-        'datasources.yaml': std.manifestYamlDoc({
-          apiVersion: 1,
-          datasources: [datasource for datasource in std.objectValues(datasources)],
-        }),
-      }) + configMap.metadata.withLabels($.grafana.labels.selector),
-      dashboards: configMap.new(this.name + '-dashboards',
-        {'dashboards.yaml': std.manifestYamlDoc({apiVersion: 1, providers: dashboards})}
-        + {[dashboard.file]: dashboard.definition for dashboard in this.dashboards}
-      ) + configMap.metadata.withLabels(this.labels.selector),
-      grafana: configMap.new(this.name, {
-        'grafana.ini': (importstr '../../config/grafana.ini'),
-      }) + configMap.metadata.withLabels(this.labels.selector),
-    }
   },
 }

--- a/grafana/deployment/kubernetes/deployment.libsonnet
+++ b/grafana/deployment/kubernetes/deployment.libsonnet
@@ -9,54 +9,56 @@
 
   grafana+: {
     local this = self,
-    container:: container.new(this.name, this.image)
-      + container.withPorts([containerPort.newNamed(this.ports.internal, 'http')])
-      + container.withEnv(
-        [
-          envVar.fromSecretRef('GF_SECURITY_ADMIN_USER', this.name, 'admin_username'),
-          envVar.fromSecretRef('GF_SECURITY_ADMIN_PASSWORD', this.name, 'admin_password'),
-          envVar.fromSecretRef('INFLUX_API_TOKEN', this.name + '-influx-db-token', 'token'),
-        ]
-        + [envVar.new(name, std.toString(this.env[name])) for name in std.objectFields(this.env)],
-      )
-      + container.withVolumeMounts([
-        volumeMount.new('config', '/etc/grafana/grafana.ini', true) + volumeMount.withSubPath('grafana.ini'),
-        volumeMount.new('dashboards', '/var/lib/grafana/dashboards', true),
-        volumeMount.new('dashboards', '/etc/grafana/provisioning/dashboards/dashboards.yaml', true)
-        + volumeMount.withSubPath('dashboards.yaml'),
-        volumeMount.new('datasources', '/etc/grafana/provisioning/datasources', true),
-        volumeMount.new(this.name, '/var/lib/grafana'),
-      ])
-      + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
-      + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
-      + container.livenessProbe.withPeriodSeconds(60)
-      + container.livenessProbe.httpGet.withPath('/api/health')
-      + container.livenessProbe.httpGet.withPort(this.ports.internal)
-      + container.readinessProbe.httpGet.withPath('/api/health')
-      + container.readinessProbe.httpGet.withPort(this.ports.internal)
-      + container.startupProbe.httpGet.withPath('/api/health')
-      + container.startupProbe.httpGet.withPort(this.ports.internal)
-      + container.startupProbe.withFailureThreshold(30)
-      + container.startupProbe.withPeriodSeconds(10),
-    initContainer:: container.new(this.name + '-setup-permissions', this.image)
-      + container.withCommand(["chown", "-R", "grafana:root", "/grafana"])
-      + container.withVolumeMounts([
-        volumeMount.new(this.name, '/grafana'),
-      ])
-      + container.securityContext.withRunAsUser(0),
-    deployment: deployment.new(name = this.name, containers = [this.container], replicas = 1)
-      + deployment.metadata.withAnnotations(this.annotations.deployment)
-      + deployment.metadata.withLabels(this.labels.deployment)
-      + deployment.spec.selector.withMatchLabels(this.labels.selector)
-      + deployment.spec.template.metadata.withAnnotations(this.annotations.pod)
-      + deployment.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
-      + deployment.spec.template.spec.withInitContainers([this.initContainer])
-      + deployment.spec.template.spec.withServiceAccount(this.name)
-      + deployment.spec.template.spec.withVolumes([
-        volume.fromConfigMap('config', this.name),
-        volume.fromConfigMap('dashboards', this.name + '-dashboards'),
-        volume.fromConfigMap('datasources', this.name + '-datasources'),
-        volume.fromPersistentVolumeClaim(this.name, 'observability-' + this.name),
-      ]),
+    deployables+: {
+      container:: container.new(this.name, this.image)
+        + container.withPorts([containerPort.newNamed(this.ports.internal, 'http')])
+        + container.withEnv(
+          [
+            envVar.fromSecretRef('GF_SECURITY_ADMIN_USER', this.name, 'admin_username'),
+            envVar.fromSecretRef('GF_SECURITY_ADMIN_PASSWORD', this.name, 'admin_password'),
+            envVar.fromSecretRef('INFLUX_API_TOKEN', this.name + '-influx-db-token', 'token'),
+          ]
+          + [envVar.new(name, std.toString(this.env[name])) for name in std.objectFields(this.env)],
+        )
+        + container.withVolumeMounts([
+          volumeMount.new('config', '/etc/grafana/grafana.ini', true) + volumeMount.withSubPath('grafana.ini'),
+          volumeMount.new('dashboards', '/var/lib/grafana/dashboards', true),
+          volumeMount.new('dashboards', '/etc/grafana/provisioning/dashboards/dashboards.yaml', true)
+          + volumeMount.withSubPath('dashboards.yaml'),
+          volumeMount.new('datasources', '/etc/grafana/provisioning/datasources', true),
+          volumeMount.new(this.name, '/var/lib/grafana'),
+        ])
+        + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
+        + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
+        + container.livenessProbe.withPeriodSeconds(60)
+        + container.livenessProbe.httpGet.withPath('/api/health')
+        + container.livenessProbe.httpGet.withPort(this.ports.internal)
+        + container.readinessProbe.httpGet.withPath('/api/health')
+        + container.readinessProbe.httpGet.withPort(this.ports.internal)
+        + container.startupProbe.httpGet.withPath('/api/health')
+        + container.startupProbe.httpGet.withPort(this.ports.internal)
+        + container.startupProbe.withFailureThreshold(30)
+        + container.startupProbe.withPeriodSeconds(10),
+      initContainer:: container.new(this.name + '-setup-permissions', this.image)
+        + container.withCommand(["chown", "-R", "grafana:root", "/grafana"])
+        + container.withVolumeMounts([
+          volumeMount.new(this.name, '/grafana'),
+        ])
+        + container.securityContext.withRunAsUser(0),
+      deployment: deployment.new(name = this.name, containers = [this.deployables.container], replicas = 1)
+        + deployment.metadata.withAnnotations(this.annotations.deployment)
+        + deployment.metadata.withLabels(this.labels.deployment)
+        + deployment.spec.selector.withMatchLabels(this.labels.selector)
+        + deployment.spec.template.metadata.withAnnotations(this.annotations.pod)
+        + deployment.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
+        + deployment.spec.template.spec.withInitContainers([this.deployables.initContainer])
+        + deployment.spec.template.spec.withServiceAccount(this.name)
+        + deployment.spec.template.spec.withVolumes([
+          volume.fromConfigMap('config', this.name),
+          volume.fromConfigMap('dashboards', this.name + '-dashboards'),
+          volume.fromConfigMap('datasources', this.name + '-datasources'),
+          volume.fromPersistentVolumeClaim(this.name, 'observability-' + this.name),
+        ]),
+    },
   },
 }

--- a/grafana/deployment/kubernetes/ingress.libsonnet
+++ b/grafana/deployment/kubernetes/ingress.libsonnet
@@ -7,31 +7,33 @@
 
   grafana+: {
     local this = self,
-    ingress: ingress.new(this.name)
-      + ingress.metadata.withAnnotations(
-        this.annotations.ingress
+    deployables+: {
+      ingress: ingress.new(this.name)
+        + ingress.metadata.withAnnotations(
+          this.annotations.ingress
+          + (
+            if this.security.tls.enabled
+            then {'cert-manager.io/issuer': this.security.tls.issuer}
+            else {}
+          ),
+        )
+        + ingress.metadata.withLabels(this.labels.selector)
+        + ingress.spec.withRules([
+            ingressRule.withHost(this.host)
+              + ingressRule.http.withPaths([
+                  httpIngressPath.withPath(this.path)
+                  + httpIngressPath.withPathType('Prefix')
+                  + httpIngressPath.backend.service.withName(this.name)
+                  + httpIngressPath.backend.service.port.withNumber(this.ports.external),
+                ])
+          ])
         + (
           if this.security.tls.enabled
-          then {'cert-manager.io/issuer': this.security.tls.issuer}
+          then ingress.spec.withTls(
+            ingressTLS.withHosts(this.host) + ingressTLS.withSecretName(this.name + '-certificate'),
+          )
           else {}
         ),
-      )
-      + ingress.metadata.withLabels(this.labels.selector)
-      + ingress.spec.withRules([
-          ingressRule.withHost(this.host)
-            + ingressRule.http.withPaths([
-                httpIngressPath.withPath(this.path)
-                + httpIngressPath.withPathType('Prefix')
-                + httpIngressPath.backend.service.withName(this.name)
-                + httpIngressPath.backend.service.port.withNumber(this.ports.external),
-              ])
-        ])
-      + (
-        if this.security.tls.enabled
-        then ingress.spec.withTls(
-          ingressTLS.withHosts(this.host) + ingressTLS.withSecretName(this.name + '-certificate'),
-        )
-        else {}
-      ),
+    },
   },
 }

--- a/grafana/deployment/kubernetes/rbac.libsonnet
+++ b/grafana/deployment/kubernetes/rbac.libsonnet
@@ -4,8 +4,10 @@
 
   grafana+: {
     local this = self,
-    serviceAccount: serviceAccount.new(this.name)
-      + serviceAccount.metadata.withLabels(this.labels.selector)
-      + serviceAccount.withAutomountServiceAccountToken(true),
+    deployables+: {
+      serviceAccount: serviceAccount.new(this.name)
+        + serviceAccount.metadata.withLabels(this.labels.selector)
+        + serviceAccount.withAutomountServiceAccountToken(true),
+    },
   },
 }

--- a/grafana/deployment/kubernetes/secret.libsonnet
+++ b/grafana/deployment/kubernetes/secret.libsonnet
@@ -4,16 +4,18 @@
 
   grafana+: {
     local this = self,
-    secrets: {
-      grafana: secret.new(this.name, {
-        admin_username: std.base64(this.secrets.admin.username),
-        admin_password: std.base64(this.secrets.admin.password),
-      })
-      + secret.metadata.withLabels(this.labels.selector),
-      influxDB: secret.new(this.name + '-influx-db-token', {
-        token: std.base64($.influxDB.secrets.token),
-      })
-      + secret.metadata.withLabels(this.labels.selector),
-    }
+    deployables+: {
+      secrets: {
+        grafana: secret.new(this.name, {
+          admin_username: std.base64(this.secrets.admin.username),
+          admin_password: std.base64(this.secrets.admin.password),
+        })
+        + secret.metadata.withLabels(this.labels.selector),
+        influxDB: secret.new(this.name + '-influx-db-token', {
+          token: std.base64($.influxDB.secrets.token),
+        })
+        + secret.metadata.withLabels(this.labels.selector),
+      },
+    },
   },
 }

--- a/grafana/deployment/kubernetes/service.libsonnet
+++ b/grafana/deployment/kubernetes/service.libsonnet
@@ -5,11 +5,13 @@
 
   grafana+: {
     local this = self,
-    service: service.new(
-      this.name,
-      this.labels.selector,
-      [servicePort.newNamed('http', this.ports.external, this.ports.internal)],
-    )
-      + service.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      service: service.new(
+        this.name,
+        this.labels.selector,
+        [servicePort.newNamed('http', this.ports.external, this.ports.internal)],
+      )
+        + service.metadata.withLabels(this.labels.selector),
+    },
   },
 }

--- a/grafana/deployment/kubernetes/storage.libsonnet
+++ b/grafana/deployment/kubernetes/storage.libsonnet
@@ -6,35 +6,37 @@
 
   grafana+: {
     local this = self,
-    persistentVolume: persistentVolume.new('observability-' + this.name)
-      + persistentVolume.metadata.withLabels(this.labels.selector)
-      + persistentVolume.spec.withAccessModes(['ReadWriteOnce'])
-      + persistentVolume.spec.withCapacity({storage: this.storage.size})
-      + persistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
-      + persistentVolume.spec.withStorageClassName(this.storage.class.name)
-      + (
-        if std.objectHasAll(this.storage, 'nfs') && std.objectHasAll(this.storage.nfs, 'server')
-        then persistentVolume.spec.nfs.withServer(this.storage.nfs.server)
-          + persistentVolume.spec.nfs.withPath(this.storage.path)
-          + persistentVolume.spec.nfs.withReadOnly(false)
-        else persistentVolume.spec.hostPath.withPath(this.storage.path)
+    deployables+: {
+      persistentVolume: persistentVolume.new('observability-' + this.name)
+        + persistentVolume.metadata.withLabels(this.labels.selector)
+        + persistentVolume.spec.withAccessModes(['ReadWriteOnce'])
+        + persistentVolume.spec.withCapacity({storage: this.storage.size})
+        + persistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
+        + persistentVolume.spec.withStorageClassName(this.storage.class.name)
+        + (
+          if std.objectHasAll(this.storage, 'nfs') && std.objectHasAll(this.storage.nfs, 'server')
+          then persistentVolume.spec.nfs.withServer(this.storage.nfs.server)
+            + persistentVolume.spec.nfs.withPath(this.storage.path)
+            + persistentVolume.spec.nfs.withReadOnly(false)
+          else persistentVolume.spec.hostPath.withPath(this.storage.path)
+        ),
+      persistentVolumeClaim: persistentVolumeClaim.new('observability-' + this.name)
+        + persistentVolumeClaim.metadata.withLabels(this.labels.selector)
+        + persistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
+        + persistentVolumeClaim.spec.withStorageClassName(this.storage.class.name)
+        + persistentVolumeClaim.spec.resources.withRequests({storage: this.storage.size}),
+      storageClass: (
+        if std.objectHasAll(this.storage.class, 'name') && std.objectHasAll(this.storage.class, 'provisioner')
+        then storageClass.new(this.storage.class.name)
+          + storageClass.withParameters(
+              if std.objectHasAll(this.storage.class, 'parameters')
+              then this.storage.class.parameters
+              else {}
+            )
+          + storageClass.withProvisioner(this.storage.class.provisioner)
+          + storageClass.withReclaimPolicy('Retain')
+        else {}
       ),
-    persistentVolumeClaim: persistentVolumeClaim.new('observability-' + this.name)
-      + persistentVolumeClaim.metadata.withLabels(this.labels.selector)
-      + persistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
-      + persistentVolumeClaim.spec.withStorageClassName(this.storage.class.name)
-      + persistentVolumeClaim.spec.resources.withRequests({storage: this.storage.size}),
-    storageClass: (
-      if std.objectHasAll(this.storage.class, 'name') && std.objectHasAll(this.storage.class, 'provisioner')
-      then storageClass.new(this.storage.class.name)
-        + storageClass.withParameters(
-            if std.objectHasAll(this.storage.class, 'parameters')
-            then this.storage.class.parameters
-            else {}
-          )
-        + storageClass.withProvisioner(this.storage.class.provisioner)
-        + storageClass.withReclaimPolicy('Retain')
-      else {}
-    ),
+    },
   },
 }

--- a/influxdb/deployment/kubernetes/certificate.libsonnet
+++ b/influxdb/deployment/kubernetes/certificate.libsonnet
@@ -2,26 +2,28 @@
 {
   influxDB+: {
     local this = self,
-    certificate: (
-      if this.security.tls.enabled
-      then {
-        apiVersion: 'cert-manager.io/v1',
-        kind: 'Certificate',
-        metadata: {
-          labels: {
-            'app.kubernetes.io/name': this.name,
+    deployables+: {
+      certificate: (
+        if this.security.tls.enabled
+        then {
+          apiVersion: 'cert-manager.io/v1',
+          kind: 'Certificate',
+          metadata: {
+            labels: {
+              'app.kubernetes.io/name': this.name,
+            },
+            name: this.name,
           },
-          name: this.name,
-        },
-        spec: {
-          secretName: this.name + '-certificate',
-          issuerRef: {
-            name: this.security.tls.issuer,
+          spec: {
+            secretName: this.name + '-certificate',
+            issuerRef: {
+              name: this.security.tls.issuer,
+            },
+            dnsNames: [this.host],
           },
-          dnsNames: [this.host],
-        },
-      }
-      else {}
-    ),
-  }
+        }
+        else {}
+      ),
+    },
+  },
 }

--- a/influxdb/deployment/kubernetes/deployment.libsonnet
+++ b/influxdb/deployment/kubernetes/deployment.libsonnet
@@ -9,41 +9,43 @@
 
   influxDB+: {
     local this = self,
-    container:: container.new(this.name, this.image)
-      + container.withPorts([containerPort.newNamed(this.ports.internal, 'http') + containerPort.withProtocol('TCP')])
-      + container.withEnv([
-        envVar.new('DOCKER_INFLUXDB_INIT_BUCKET', this.bucket),
-        envVar.new('DOCKER_INFLUXDB_INIT_MODE', 'setup'),
-        envVar.new('DOCKER_INFLUXDB_INIT_ORG', this.organisation),
-        envVar.new('DOCKER_INFLUXDB_INIT_RETENTION', this.retention),
-        envVar.fromSecretRef('DOCKER_INFLUXDB_INIT_ADMIN_TOKEN', this.name, 'token'),
-        envVar.fromSecretRef('DOCKER_INFLUXDB_INIT_USERNAME', this.name, 'username'),
-        envVar.fromSecretRef('DOCKER_INFLUXDB_INIT_PASSWORD', this.name, 'password'),
-      ])
-      + container.withVolumeMounts([
-        volumeMount.new(this.name, '/var/lib/influxdb2'),
-      ])
-      + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
-      + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
-      + container.livenessProbe.withPeriodSeconds(60)
-      + container.livenessProbe.httpGet.withPath('/health')
-      + container.livenessProbe.httpGet.withPort(this.ports.internal)
-      + container.readinessProbe.httpGet.withPath('/health')
-      + container.readinessProbe.httpGet.withPort(this.ports.internal)
-      + container.startupProbe.httpGet.withPath('/health')
-      + container.startupProbe.httpGet.withPort(this.ports.internal)
-      + container.startupProbe.withFailureThreshold(30)
-      + container.startupProbe.withPeriodSeconds(10),
-    deployment: deployment.new(name = this.name, containers = [this.container], replicas = 1)
-      + deployment.metadata.withAnnotations(this.annotations.deployment)
-      + deployment.metadata.withLabels(this.labels.deployment)
-      + deployment.spec.selector.withMatchLabels(this.labels.selector)
-      + deployment.spec.template.metadata.withAnnotations(this.annotations.pod)
-      + deployment.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
-      + deployment.spec.template.spec.withServiceAccount(this.name)
-      + deployment.spec.template.spec.withTerminationGracePeriodSeconds(60)
-      + deployment.spec.template.spec.withVolumes([
-        volume.fromPersistentVolumeClaim(this.name, 'observability-' + this.name)
-      ]),
+    deployables+: {
+      container:: container.new(this.name, this.image)
+        + container.withPorts([containerPort.newNamed(this.ports.internal, 'http') + containerPort.withProtocol('TCP')])
+        + container.withEnv([
+          envVar.new('DOCKER_INFLUXDB_INIT_BUCKET', this.bucket),
+          envVar.new('DOCKER_INFLUXDB_INIT_MODE', 'setup'),
+          envVar.new('DOCKER_INFLUXDB_INIT_ORG', this.organisation),
+          envVar.new('DOCKER_INFLUXDB_INIT_RETENTION', this.retention),
+          envVar.fromSecretRef('DOCKER_INFLUXDB_INIT_ADMIN_TOKEN', this.name, 'token'),
+          envVar.fromSecretRef('DOCKER_INFLUXDB_INIT_USERNAME', this.name, 'username'),
+          envVar.fromSecretRef('DOCKER_INFLUXDB_INIT_PASSWORD', this.name, 'password'),
+        ])
+        + container.withVolumeMounts([
+          volumeMount.new(this.name, '/var/lib/influxdb2'),
+        ])
+        + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
+        + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
+        + container.livenessProbe.withPeriodSeconds(60)
+        + container.livenessProbe.httpGet.withPath('/health')
+        + container.livenessProbe.httpGet.withPort(this.ports.internal)
+        + container.readinessProbe.httpGet.withPath('/health')
+        + container.readinessProbe.httpGet.withPort(this.ports.internal)
+        + container.startupProbe.httpGet.withPath('/health')
+        + container.startupProbe.httpGet.withPort(this.ports.internal)
+        + container.startupProbe.withFailureThreshold(30)
+        + container.startupProbe.withPeriodSeconds(10),
+      deployment: deployment.new(name = this.name, containers = [this.deployables.container], replicas = 1)
+        + deployment.metadata.withAnnotations(this.annotations.deployment)
+        + deployment.metadata.withLabels(this.labels.deployment)
+        + deployment.spec.selector.withMatchLabels(this.labels.selector)
+        + deployment.spec.template.metadata.withAnnotations(this.annotations.pod)
+        + deployment.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
+        + deployment.spec.template.spec.withServiceAccount(this.name)
+        + deployment.spec.template.spec.withTerminationGracePeriodSeconds(60)
+        + deployment.spec.template.spec.withVolumes([
+          volume.fromPersistentVolumeClaim(this.name, 'observability-' + this.name)
+        ]),
+    },
   },
 }

--- a/influxdb/deployment/kubernetes/rbac.libsonnet
+++ b/influxdb/deployment/kubernetes/rbac.libsonnet
@@ -4,8 +4,10 @@
 
   influxDB+: {
     local this = self,
-    serviceAccount: serviceAccount.new(this.name)
-      + serviceAccount.metadata.withLabels(this.labels.selector)
-      + serviceAccount.withAutomountServiceAccountToken(true),
+    deployables+: {
+      serviceAccount: serviceAccount.new(this.name)
+        + serviceAccount.metadata.withLabels(this.labels.selector)
+        + serviceAccount.withAutomountServiceAccountToken(true),
+    },
   },
 }

--- a/influxdb/deployment/kubernetes/secret.libsonnet
+++ b/influxdb/deployment/kubernetes/secret.libsonnet
@@ -4,11 +4,13 @@
 
   influxDB+: {
     local this = self,
-    secret: secret.new(this.name, {
-      username: std.base64(this.secrets.username),
-      password: std.base64(this.secrets.password),
-      token: std.base64(this.secrets.token),
-    })
-    + secret.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      secret: secret.new(this.name, {
+        username: std.base64(this.secrets.username),
+        password: std.base64(this.secrets.password),
+        token: std.base64(this.secrets.token),
+      })
+      + secret.metadata.withLabels(this.labels.selector),
+    },
   },
 }

--- a/influxdb/deployment/kubernetes/service.libsonnet
+++ b/influxdb/deployment/kubernetes/service.libsonnet
@@ -5,11 +5,13 @@
 
   influxDB+: {
     local this = self,
-    service: service.new(
-      this.name,
-      this.labels.selector,
-      [servicePort.newNamed('http', this.ports.external, this.ports.internal)],
-    )
-      + service.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      service: service.new(
+        this.name,
+        this.labels.selector,
+        [servicePort.newNamed('http', this.ports.external, this.ports.internal)],
+      )
+        + service.metadata.withLabels(this.labels.selector),
+    },
   },
 }

--- a/influxdb/deployment/kubernetes/storage.libsonnet
+++ b/influxdb/deployment/kubernetes/storage.libsonnet
@@ -6,35 +6,37 @@
 
   influxDB+: {
     local this = self,
-    persistentVolume: persistentVolume.new('observability-' + this.name)
-      + persistentVolume.metadata.withLabels(this.labels.selector)
-      + persistentVolume.spec.withAccessModes(['ReadWriteOnce'])
-      + persistentVolume.spec.withCapacity({storage: this.storage.size})
-      + persistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
-      + persistentVolume.spec.withStorageClassName(this.storage.class.name)
-      + (
-        if std.objectHasAll(this.storage, 'nfs') && std.objectHasAll(this.storage.nfs, 'server')
-        then persistentVolume.spec.nfs.withServer(this.storage.nfs.server)
-          + persistentVolume.spec.nfs.withPath(this.storage.path)
-          + persistentVolume.spec.nfs.withReadOnly(false)
-        else persistentVolume.spec.hostPath.withPath(this.storage.path)
+    deployables+: {
+      persistentVolume: persistentVolume.new('observability-' + this.name)
+        + persistentVolume.metadata.withLabels(this.labels.selector)
+        + persistentVolume.spec.withAccessModes(['ReadWriteOnce'])
+        + persistentVolume.spec.withCapacity({storage: this.storage.size})
+        + persistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
+        + persistentVolume.spec.withStorageClassName(this.storage.class.name)
+        + (
+          if std.objectHasAll(this.storage, 'nfs') && std.objectHasAll(this.storage.nfs, 'server')
+          then persistentVolume.spec.nfs.withServer(this.storage.nfs.server)
+            + persistentVolume.spec.nfs.withPath(this.storage.path)
+            + persistentVolume.spec.nfs.withReadOnly(false)
+          else persistentVolume.spec.hostPath.withPath(this.storage.path)
+        ),
+      persistentVolumeClaim: persistentVolumeClaim.new('observability-' + this.name)
+        + persistentVolumeClaim.metadata.withLabels(this.labels.selector)
+        + persistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
+        + persistentVolumeClaim.spec.withStorageClassName(this.storage.class.name)
+        + persistentVolumeClaim.spec.resources.withRequests({storage: this.storage.size}),
+      storageClass: (
+        if std.objectHasAll(this.storage.class, 'name') && std.objectHasAll(this.storage.class, 'provisioner')
+        then storageClass.new(this.storage.class.name)
+          + storageClass.withParameters(
+              if std.objectHasAll(this.storage.class, 'parameters')
+              then this.storage.class.parameters
+              else {}
+            )
+          + storageClass.withProvisioner(this.storage.class.provisioner)
+          + storageClass.withReclaimPolicy('Retain')
+        else {}
       ),
-    persistentVolumeClaim: persistentVolumeClaim.new('observability-' + this.name)
-      + persistentVolumeClaim.metadata.withLabels(this.labels.selector)
-      + persistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
-      + persistentVolumeClaim.spec.withStorageClassName(this.storage.class.name)
-      + persistentVolumeClaim.spec.resources.withRequests({storage: this.storage.size}),
-    storageClass: (
-      if std.objectHasAll(this.storage.class, 'name') && std.objectHasAll(this.storage.class, 'provisioner')
-      then storageClass.new(this.storage.class.name)
-        + storageClass.withParameters(
-            if std.objectHasAll(this.storage.class, 'parameters')
-            then this.storage.class.parameters
-            else {}
-          )
-        + storageClass.withProvisioner(this.storage.class.provisioner)
-        + storageClass.withReclaimPolicy('Retain')
-      else {}
-    ),
+    },
   },
 }

--- a/loki/deployment/kubernetes/config-map.libsonnet
+++ b/loki/deployment/kubernetes/config-map.libsonnet
@@ -4,17 +4,18 @@
 
   loki+: {
     local this = self,
+    deployables+: {
+      local config = std.parseYaml(importstr '../../config/loki.yaml') + {
+        limits_config+: {
+          retention_period: this.retention,
+        },
+        server+: {
+          http_listen_port: this.ports.internal,
+        },
+      },
 
-    local config = std.parseYaml(importstr '../../config/loki.yaml') + {
-      limits_config+: {
-        retention_period: this.retention,
-      },
-      server+: {
-        http_listen_port: this.ports.internal,
-      },
+      configMap: configMap.new(this.name, {'local-config.yaml': std.manifestYamlDoc(config)})
+        + configMap.metadata.withLabels(this.labels.selector),
     },
-
-    configMap: configMap.new(this.name, {'local-config.yaml': std.manifestYamlDoc(config)})
-      + configMap.metadata.withLabels(this.labels.selector),
   },
 }

--- a/loki/deployment/kubernetes/deployment.libsonnet
+++ b/loki/deployment/kubernetes/deployment.libsonnet
@@ -8,41 +8,43 @@
 
   loki+: {
     local this = self,
-    container:: container.new(this.name, this.image)
-      + container.withPorts(containerPort.newNamed(this.ports.internal, 'http'))
-      + container.withVolumeMounts([
-        volumeMount.new('config', '/etc/loki', true),
-        volumeMount.new(this.name, '/loki'),
-      ])
-      + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
-      + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
-      + container.livenessProbe.withPeriodSeconds(60)
-      + container.livenessProbe.httpGet.withPath('/ready')
-      + container.livenessProbe.httpGet.withPort(this.ports.internal)
-      + container.readinessProbe.httpGet.withPath('/ready')
-      + container.readinessProbe.httpGet.withPort(this.ports.internal)
-      + container.startupProbe.httpGet.withPath('/ready')
-      + container.startupProbe.httpGet.withPort(this.ports.internal)
-      + container.startupProbe.withFailureThreshold(30)
-      + container.startupProbe.withPeriodSeconds(10),
-    initContainer:: container.new(this.name + '-setup-permissions', this.image)
-      + container.withCommand(["chown", "-R", "loki:loki", "/loki"])
-      + container.withVolumeMounts([
-        volumeMount.new(this.name, '/loki'),
-      ])
-      + container.securityContext.withRunAsUser(0),
-    deployment: deployment.new(name = this.name, containers = [this.container], replicas = 1)
-      + deployment.metadata.withAnnotations(this.annotations.deployment)
-      + deployment.metadata.withLabels(this.labels.deployment)
-      + deployment.spec.selector.withMatchLabels(this.labels.selector)
-      + deployment.spec.template.metadata.withAnnotations(this.annotations.pod)
-      + deployment.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
-      + deployment.spec.template.spec.withInitContainers([this.initContainer])
-      + deployment.spec.template.spec.withServiceAccount(this.name)
-      + deployment.spec.template.spec.withTerminationGracePeriodSeconds(60)
-      + deployment.spec.template.spec.withVolumes([
-        volume.fromConfigMap('config', this.name),
-        volume.fromPersistentVolumeClaim(this.name, 'observability-' + this.name),
-      ]),
+    deployables+: {
+      container:: container.new(this.name, this.image)
+        + container.withPorts(containerPort.newNamed(this.ports.internal, 'http'))
+        + container.withVolumeMounts([
+          volumeMount.new('config', '/etc/loki', true),
+          volumeMount.new(this.name, '/loki'),
+        ])
+        + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
+        + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
+        + container.livenessProbe.withPeriodSeconds(60)
+        + container.livenessProbe.httpGet.withPath('/ready')
+        + container.livenessProbe.httpGet.withPort(this.ports.internal)
+        + container.readinessProbe.httpGet.withPath('/ready')
+        + container.readinessProbe.httpGet.withPort(this.ports.internal)
+        + container.startupProbe.httpGet.withPath('/ready')
+        + container.startupProbe.httpGet.withPort(this.ports.internal)
+        + container.startupProbe.withFailureThreshold(30)
+        + container.startupProbe.withPeriodSeconds(10),
+      initContainer:: container.new(this.name + '-setup-permissions', this.image)
+        + container.withCommand(["chown", "-R", "loki:loki", "/loki"])
+        + container.withVolumeMounts([
+          volumeMount.new(this.name, '/loki'),
+        ])
+        + container.securityContext.withRunAsUser(0),
+      deployment: deployment.new(name = this.name, containers = [this.deployables.container], replicas = 1)
+        + deployment.metadata.withAnnotations(this.annotations.deployment)
+        + deployment.metadata.withLabels(this.labels.deployment)
+        + deployment.spec.selector.withMatchLabels(this.labels.selector)
+        + deployment.spec.template.metadata.withAnnotations(this.annotations.pod)
+        + deployment.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
+        + deployment.spec.template.spec.withInitContainers([this.deployables.initContainer])
+        + deployment.spec.template.spec.withServiceAccount(this.name)
+        + deployment.spec.template.spec.withTerminationGracePeriodSeconds(60)
+        + deployment.spec.template.spec.withVolumes([
+          volume.fromConfigMap('config', this.name),
+          volume.fromPersistentVolumeClaim(this.name, 'observability-' + this.name),
+        ]),
+    },
   },
 }

--- a/loki/deployment/kubernetes/rbac.libsonnet
+++ b/loki/deployment/kubernetes/rbac.libsonnet
@@ -4,8 +4,10 @@
 
   loki+: {
     local this = self,
-    serviceAccount: serviceAccount.new(this.name)
-      + serviceAccount.metadata.withLabels(this.labels.selector)
-      + serviceAccount.withAutomountServiceAccountToken(true),
+    deployables+: {
+      serviceAccount: serviceAccount.new(this.name)
+        + serviceAccount.metadata.withLabels(this.labels.selector)
+        + serviceAccount.withAutomountServiceAccountToken(true),
+    },
   },
 }

--- a/loki/deployment/kubernetes/service.libsonnet
+++ b/loki/deployment/kubernetes/service.libsonnet
@@ -5,11 +5,13 @@
 
   loki+: {
     local this = self,
-    service: service.new(
-      this.name,
-      this.labels.selector,
-      [servicePort.newNamed('http', this.ports.external, this.ports.internal)],
-    )
-      + service.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      service: service.new(
+        this.name,
+        this.labels.selector,
+        [servicePort.newNamed('http', this.ports.external, this.ports.internal)],
+      )
+        + service.metadata.withLabels(this.labels.selector),
+    },
   },
 }

--- a/loki/deployment/kubernetes/storage.libsonnet
+++ b/loki/deployment/kubernetes/storage.libsonnet
@@ -6,35 +6,37 @@
 
   loki+: {
     local this = self,
-    persistentVolume: persistentVolume.new('observability-' + this.name)
-      + persistentVolume.metadata.withLabels(this.labels.selector)
-      + persistentVolume.spec.withAccessModes(['ReadWriteOnce'])
-      + persistentVolume.spec.withCapacity({storage: this.storage.size})
-      + persistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
-      + persistentVolume.spec.withStorageClassName(this.storage.class.name)
-      + (
-        if std.objectHasAll(this.storage, 'nfs') && std.objectHasAll(this.storage.nfs, 'server')
-        then persistentVolume.spec.nfs.withServer(this.storage.nfs.server)
-          + persistentVolume.spec.nfs.withPath(this.storage.path)
-          + persistentVolume.spec.nfs.withReadOnly(false)
-        else persistentVolume.spec.hostPath.withPath(this.storage.path)
+    deployables+: {
+      persistentVolume: persistentVolume.new('observability-' + this.name)
+        + persistentVolume.metadata.withLabels(this.labels.selector)
+        + persistentVolume.spec.withAccessModes(['ReadWriteOnce'])
+        + persistentVolume.spec.withCapacity({storage: this.storage.size})
+        + persistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
+        + persistentVolume.spec.withStorageClassName(this.storage.class.name)
+        + (
+          if std.objectHasAll(this.storage, 'nfs') && std.objectHasAll(this.storage.nfs, 'server')
+          then persistentVolume.spec.nfs.withServer(this.storage.nfs.server)
+            + persistentVolume.spec.nfs.withPath(this.storage.path)
+            + persistentVolume.spec.nfs.withReadOnly(false)
+          else persistentVolume.spec.hostPath.withPath(this.storage.path)
+        ),
+      persistentVolumeClaim: persistentVolumeClaim.new('observability-' + this.name)
+        + persistentVolumeClaim.metadata.withLabels(this.labels.selector)
+        + persistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
+        + persistentVolumeClaim.spec.withStorageClassName(this.storage.class.name)
+        + persistentVolumeClaim.spec.resources.withRequests({storage: this.storage.size}),
+      storageClass: (
+        if std.objectHasAll(this.storage.class, 'name') && std.objectHasAll(this.storage.class, 'provisioner')
+        then storageClass.new(this.storage.class.name)
+          + storageClass.withParameters(
+              if std.objectHasAll(this.storage.class, 'parameters')
+              then this.storage.class.parameters
+              else {}
+            )
+          + storageClass.withProvisioner(this.storage.class.provisioner)
+          + storageClass.withReclaimPolicy('Retain')
+        else {}
       ),
-    persistentVolumeClaim: persistentVolumeClaim.new('observability-' + this.name)
-      + persistentVolumeClaim.metadata.withLabels(this.labels.selector)
-      + persistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
-      + persistentVolumeClaim.spec.withStorageClassName(this.storage.class.name)
-      + persistentVolumeClaim.spec.resources.withRequests({storage: this.storage.size}),
-    storageClass: (
-      if std.objectHasAll(this.storage.class, 'name') && std.objectHasAll(this.storage.class, 'provisioner')
-      then storageClass.new(this.storage.class.name)
-        + storageClass.withParameters(
-            if std.objectHasAll(this.storage.class, 'parameters')
-            then this.storage.class.parameters
-            else {}
-          )
-        + storageClass.withProvisioner(this.storage.class.provisioner)
-        + storageClass.withReclaimPolicy('Retain')
-      else {}
-    ),
+    },
   },
 }

--- a/tempo/deployment/kubernetes/config-map.libsonnet
+++ b/tempo/deployment/kubernetes/config-map.libsonnet
@@ -4,7 +4,9 @@
 
   tempo+: {
     local this = self,
-    configMap: configMap.new(this.name, {'tempo.yaml': (importstr '../../config/tempo.yaml')})
-      + configMap.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      configMap: configMap.new(this.name, {'tempo.yaml': (importstr '../../config/tempo.yaml')})
+        + configMap.metadata.withLabels(this.labels.selector),
+    },
   },
 }

--- a/tempo/deployment/kubernetes/deployment.libsonnet
+++ b/tempo/deployment/kubernetes/deployment.libsonnet
@@ -8,37 +8,39 @@
 
   tempo+: {
     local this = self,
-    container:: container.new(this.name, this.image)
-      + container.withArgs(['-config.file=/etc/tempo/tempo.yaml'])
-      + container.withPorts([
-        containerPort.newNamed(this.ports[port].internal, port) for port in std.objectFieldsAll(this.ports)
-      ])
-      + container.withVolumeMounts([
-        volumeMount.new('config', '/etc/tempo', true),
-        volumeMount.new(this.name, '/tmp/tempo'),
-      ])
-      + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
-      + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
-      + container.livenessProbe.withPeriodSeconds(60)
-      + container.livenessProbe.httpGet.withPath('/ready')
-      + container.livenessProbe.httpGet.withPort(this.ports.tempo.internal)
-      + container.readinessProbe.httpGet.withPath('/ready')
-      + container.readinessProbe.httpGet.withPort(this.ports.tempo.internal)
-      + container.startupProbe.httpGet.withPath('/ready')
-      + container.startupProbe.httpGet.withPort(this.ports.tempo.internal)
-      + container.startupProbe.withFailureThreshold(30)
-      + container.startupProbe.withPeriodSeconds(10),
-    deployment: deployment.new(name = this.name, containers = [this.container], replicas = 1)
-      + deployment.metadata.withAnnotations(this.annotations.deployment)
-      + deployment.metadata.withLabels(this.labels.deployment)
-      + deployment.spec.selector.withMatchLabels(this.labels.selector)
-      + deployment.spec.template.metadata.withAnnotations(this.annotations.pod)
-      + deployment.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
-      + deployment.spec.template.spec.withServiceAccount(this.name)
-      + deployment.spec.template.spec.withTerminationGracePeriodSeconds(60)
-      + deployment.spec.template.spec.withVolumes([
-        volume.fromConfigMap('config', this.name),
-        volume.fromPersistentVolumeClaim(this.name, 'observability-' + this.name),
-      ]),
+    deployables+: {
+      container:: container.new(this.name, this.image)
+        + container.withArgs(['-config.file=/etc/tempo/tempo.yaml'])
+        + container.withPorts([
+          containerPort.newNamed(this.ports[port].internal, port) for port in std.objectFieldsAll(this.ports)
+        ])
+        + container.withVolumeMounts([
+          volumeMount.new('config', '/etc/tempo', true),
+          volumeMount.new(this.name, '/tmp/tempo'),
+        ])
+        + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
+        + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
+        + container.livenessProbe.withPeriodSeconds(60)
+        + container.livenessProbe.httpGet.withPath('/ready')
+        + container.livenessProbe.httpGet.withPort(this.ports.tempo.internal)
+        + container.readinessProbe.httpGet.withPath('/ready')
+        + container.readinessProbe.httpGet.withPort(this.ports.tempo.internal)
+        + container.startupProbe.httpGet.withPath('/ready')
+        + container.startupProbe.httpGet.withPort(this.ports.tempo.internal)
+        + container.startupProbe.withFailureThreshold(30)
+        + container.startupProbe.withPeriodSeconds(10),
+      deployment: deployment.new(name = this.name, containers = [this.deployables.container], replicas = 1)
+        + deployment.metadata.withAnnotations(this.annotations.deployment)
+        + deployment.metadata.withLabels(this.labels.deployment)
+        + deployment.spec.selector.withMatchLabels(this.labels.selector)
+        + deployment.spec.template.metadata.withAnnotations(this.annotations.pod)
+        + deployment.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
+        + deployment.spec.template.spec.withServiceAccount(this.name)
+        + deployment.spec.template.spec.withTerminationGracePeriodSeconds(60)
+        + deployment.spec.template.spec.withVolumes([
+          volume.fromConfigMap('config', this.name),
+          volume.fromPersistentVolumeClaim(this.name, 'observability-' + this.name),
+        ]),
+    },
   },
 }

--- a/tempo/deployment/kubernetes/rbac.libsonnet
+++ b/tempo/deployment/kubernetes/rbac.libsonnet
@@ -4,8 +4,10 @@
 
   tempo+: {
     local this = self,
-    serviceAccount: serviceAccount.new(this.name)
-      + serviceAccount.metadata.withLabels(this.labels.selector)
-      + serviceAccount.withAutomountServiceAccountToken(true),
+    deployables+: {
+      serviceAccount: serviceAccount.new(this.name)
+        + serviceAccount.metadata.withLabels(this.labels.selector)
+        + serviceAccount.withAutomountServiceAccountToken(true),
+    },
   },
 }

--- a/tempo/deployment/kubernetes/service.libsonnet
+++ b/tempo/deployment/kubernetes/service.libsonnet
@@ -5,14 +5,16 @@
 
   tempo+: {
     local this = self,
-    service: service.new(
-      this.name,
-      this.labels.selector,
-      [
-        servicePort.newNamed(port, this.ports[port].external, this.ports[port].internal)
-        for port in std.objectFieldsAll(this.ports)
-      ]
-    )
-      + service.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      service: service.new(
+        this.name,
+        this.labels.selector,
+        [
+          servicePort.newNamed(port, this.ports[port].external, this.ports[port].internal)
+          for port in std.objectFieldsAll(this.ports)
+        ]
+      )
+        + service.metadata.withLabels(this.labels.selector),
+    },
   },
 }

--- a/tempo/deployment/kubernetes/storage.libsonnet
+++ b/tempo/deployment/kubernetes/storage.libsonnet
@@ -6,35 +6,37 @@
 
   tempo+: {
     local this = self,
-    persistentVolume: persistentVolume.new('observability-' + this.name)
-      + persistentVolume.metadata.withLabels(this.labels.selector)
-      + persistentVolume.spec.withAccessModes(['ReadWriteOnce'])
-      + persistentVolume.spec.withCapacity({storage: this.storage.size})
-      + persistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
-      + persistentVolume.spec.withStorageClassName(this.storage.class.name)
-      + (
-        if std.objectHasAll(this.storage, 'nfs') && std.objectHasAll(this.storage.nfs, 'server')
-        then persistentVolume.spec.nfs.withServer(this.storage.nfs.server)
-          + persistentVolume.spec.nfs.withPath(this.storage.path)
-          + persistentVolume.spec.nfs.withReadOnly(false)
-        else persistentVolume.spec.hostPath.withPath(this.storage.path)
+    deployables+: {
+      persistentVolume: persistentVolume.new('observability-' + this.name)
+        + persistentVolume.metadata.withLabels(this.labels.selector)
+        + persistentVolume.spec.withAccessModes(['ReadWriteOnce'])
+        + persistentVolume.spec.withCapacity({storage: this.storage.size})
+        + persistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
+        + persistentVolume.spec.withStorageClassName(this.storage.class.name)
+        + (
+          if std.objectHasAll(this.storage, 'nfs') && std.objectHasAll(this.storage.nfs, 'server')
+          then persistentVolume.spec.nfs.withServer(this.storage.nfs.server)
+            + persistentVolume.spec.nfs.withPath(this.storage.path)
+            + persistentVolume.spec.nfs.withReadOnly(false)
+          else persistentVolume.spec.hostPath.withPath(this.storage.path)
+        ),
+      persistentVolumeClaim: persistentVolumeClaim.new('observability-' + this.name)
+        + persistentVolumeClaim.metadata.withLabels(this.labels.selector)
+        + persistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
+        + persistentVolumeClaim.spec.withStorageClassName(this.storage.class.name)
+        + persistentVolumeClaim.spec.resources.withRequests({storage: this.storage.size}),
+      storageClass: (
+        if std.objectHasAll(this.storage.class, 'name') && std.objectHasAll(this.storage.class, 'provisioner')
+        then storageClass.new(this.storage.class.name)
+          + storageClass.withParameters(
+              if std.objectHasAll(this.storage.class, 'parameters')
+              then this.storage.class.parameters
+              else {}
+            )
+          + storageClass.withProvisioner(this.storage.class.provisioner)
+          + storageClass.withReclaimPolicy('Retain')
+        else {}
       ),
-    persistentVolumeClaim: persistentVolumeClaim.new('observability-' + this.name)
-      + persistentVolumeClaim.metadata.withLabels(this.labels.selector)
-      + persistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
-      + persistentVolumeClaim.spec.withStorageClassName(this.storage.class.name)
-      + persistentVolumeClaim.spec.resources.withRequests({storage: this.storage.size}),
-    storageClass: (
-      if std.objectHasAll(this.storage.class, 'name') && std.objectHasAll(this.storage.class, 'provisioner')
-      then storageClass.new(this.storage.class.name)
-        + storageClass.withParameters(
-            if std.objectHasAll(this.storage.class, 'parameters')
-            then this.storage.class.parameters
-            else {}
-          )
-        + storageClass.withProvisioner(this.storage.class.provisioner)
-        + storageClass.withReclaimPolicy('Retain')
-      else {}
-    ),
+    },
   },
 }

--- a/vector/deployment/kubernetes/config-map.libsonnet
+++ b/vector/deployment/kubernetes/config-map.libsonnet
@@ -4,21 +4,23 @@
 
   vector+: {
     local this = self,
-    configMap: configMap.new(this.name,
-      {
-        'vector.toml': (importstr '../../config/vector.toml')
-          + (importstr '../../config/logs/kubernetes/index.toml')
-          + (importstr '../../config/metrics/resources/container/cpu.toml')
-          + (importstr '../../config/metrics/resources/container/index.toml')
-          + (importstr '../../config/metrics/resources/container/memory.toml')
-          + (importstr '../../config/metrics/resources/host/filesystem.toml')
-          + (importstr '../../config/metrics/resources/host/host.toml')
-          + (importstr '../../config/metrics/resources/host/index.toml')
-          + (importstr '../../config/metrics/resources/host/load.toml')
-          + (importstr '../../config/metrics/resources/host/memory.toml')
-          + (importstr '../../config/metrics/resources/host/network.toml')
-          + std.join('\n', this.logging.kubernetes.transformations),
-      })
-      + configMap.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      configMap: configMap.new(this.name,
+        {
+          'vector.toml': (importstr '../../config/vector.toml')
+            + (importstr '../../config/logs/kubernetes/index.toml')
+            + (importstr '../../config/metrics/resources/container/cpu.toml')
+            + (importstr '../../config/metrics/resources/container/index.toml')
+            + (importstr '../../config/metrics/resources/container/memory.toml')
+            + (importstr '../../config/metrics/resources/host/filesystem.toml')
+            + (importstr '../../config/metrics/resources/host/host.toml')
+            + (importstr '../../config/metrics/resources/host/index.toml')
+            + (importstr '../../config/metrics/resources/host/load.toml')
+            + (importstr '../../config/metrics/resources/host/memory.toml')
+            + (importstr '../../config/metrics/resources/host/network.toml')
+            + std.join('\n', this.logging.kubernetes.transformations),
+        })
+        + configMap.metadata.withLabels(this.labels.selector),
+    },
   },
 }

--- a/vector/deployment/kubernetes/daemonset.libsonnet
+++ b/vector/deployment/kubernetes/daemonset.libsonnet
@@ -10,63 +10,65 @@
 
   vector+: {
     local this = self,
-    container:: container.new(this.name, this.image)
-      + container.withPorts([containerPort.newNamed(this.ports.internal, 'http')])
-      + container.withEnv([
-        envVar.fromFieldPath('VECTOR_SELF_NODE_NAME', 'spec.nodeName'),
-        envVar.fromFieldPath('VECTOR_SELF_POD_NAME', 'metadata.name'),
-        envVar.fromFieldPath('VECTOR_SELF_POD_NAMESPACE', 'metadata.namespace'),
-        envVar.fromSecretRef('INFLUXDB_TOKEN', 'vector-influx-db-token', 'token'),
-        envVar.fromSecretRef('KUBERNETES_API_TOKEN', 'vector-service-account-token', 'token'),
-        envVar.new('INFLUXDB_BUCKET', this.monitoring.influxDB.bucket),
-        envVar.new('INFLUXDB_ENDPOINT', this.monitoring.influxDB.endpoint),
-        envVar.new('INFLUXDB_ORG', this.monitoring.influxDB.org),
-        envVar.new('LOG', 'info'),
-        envVar.new('LOKI_ENDPOINT', 'http://' + $.loki.name + ':' + $.loki.ports.external),
-        envVar.new('PROCFS_ROOT', '/host/proc'),
-        envVar.new('SYSFS_ROOT', '/host/sys'),
-        envVar.new('VECTOR_CONFIG_DIR', '/etc/vector'),
-        envVar.new('VECTOR_INTERNAL_PORT', std.toString(this.ports.internal)),
-      ])
-      + container.withVolumeMounts([
-        volumeMount.new('config', '/etc/vector', true),
-        volumeMount.new('data-dir', '/vector-data-dir'),
-        volumeMount.new('procfs', '/host/proc', true),
-        volumeMount.new('service-account-token', '/var/run/secrets/kubernetes.io/serviceaccount/', true),
-        volumeMount.new('sysfs', '/host/sys', true),
-        volumeMount.new('var-lib', '/var/lib', true),
-        volumeMount.new('var-log', '/var/log', true),
-      ])
-      + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
-      + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
-      + container.livenessProbe.withPeriodSeconds(60)
-      + container.livenessProbe.httpGet.withPath('/health')
-      + container.livenessProbe.httpGet.withPort(this.ports.internal)
-      + container.readinessProbe.httpGet.withPath('/health')
-      + container.readinessProbe.httpGet.withPort(this.ports.internal)
-      + container.startupProbe.httpGet.withPath('/health')
-      + container.startupProbe.httpGet.withPort(this.ports.internal)
-      + container.startupProbe.withFailureThreshold(30)
-      + container.startupProbe.withPeriodSeconds(10),
-    daemonSet: daemonSet.new(name = this.name, containers = [this.container])
-      + daemonSet.metadata.withAnnotations(this.annotations.deployment)
-      + daemonSet.metadata.withLabels(this.labels.deployment)
-      + daemonSet.spec.selector.withMatchLabels(this.labels.selector)
-      + daemonSet.spec.template.metadata.withAnnotations(this.annotations.pod)
-      + daemonSet.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
-      + daemonSet.spec.template.spec.withServiceAccount(this.name)
-      + daemonSet.spec.template.spec.withTerminationGracePeriodSeconds(60)
-      + daemonSet.spec.template.spec.withTolerations([
-        toleration.withOperator('Exists') + toleration.withEffect('NoSchedule'),
-      ])
-      + daemonSet.spec.template.spec.withVolumes([
-        volume.fromConfigMap('config', this.name),
-        volume.fromHostPath('data-dir', '/var/lib/vector'),
-        volume.fromHostPath('procfs', '/proc'),
-        volume.fromHostPath('sysfs', '/sys'),
-        volume.fromHostPath('var-lib', '/var/lib'),
-        volume.fromHostPath('var-log', '/var/log'),
-        volume.fromSecret('service-account-token', 'vector-service-account-token'),
-      ]),
+    deployables+: {
+      container:: container.new(this.name, this.image)
+        + container.withPorts([containerPort.newNamed(this.ports.internal, 'http')])
+        + container.withEnv([
+          envVar.fromFieldPath('VECTOR_SELF_NODE_NAME', 'spec.nodeName'),
+          envVar.fromFieldPath('VECTOR_SELF_POD_NAME', 'metadata.name'),
+          envVar.fromFieldPath('VECTOR_SELF_POD_NAMESPACE', 'metadata.namespace'),
+          envVar.fromSecretRef('INFLUXDB_TOKEN', 'vector-influx-db-token', 'token'),
+          envVar.fromSecretRef('KUBERNETES_API_TOKEN', 'vector-service-account-token', 'token'),
+          envVar.new('INFLUXDB_BUCKET', this.monitoring.influxDB.bucket),
+          envVar.new('INFLUXDB_ENDPOINT', this.monitoring.influxDB.endpoint),
+          envVar.new('INFLUXDB_ORG', this.monitoring.influxDB.org),
+          envVar.new('LOG', 'info'),
+          envVar.new('LOKI_ENDPOINT', 'http://' + $.loki.name + ':' + $.loki.ports.external),
+          envVar.new('PROCFS_ROOT', '/host/proc'),
+          envVar.new('SYSFS_ROOT', '/host/sys'),
+          envVar.new('VECTOR_CONFIG_DIR', '/etc/vector'),
+          envVar.new('VECTOR_INTERNAL_PORT', std.toString(this.ports.internal)),
+        ])
+        + container.withVolumeMounts([
+          volumeMount.new('config', '/etc/vector', true),
+          volumeMount.new('data-dir', '/vector-data-dir'),
+          volumeMount.new('procfs', '/host/proc', true),
+          volumeMount.new('service-account-token', '/var/run/secrets/kubernetes.io/serviceaccount/', true),
+          volumeMount.new('sysfs', '/host/sys', true),
+          volumeMount.new('var-lib', '/var/lib', true),
+          volumeMount.new('var-log', '/var/log', true),
+        ])
+        + container.resources.withRequests({cpu: this.resources.cpu.request, memory: this.resources.memory.request})
+        + container.resources.withLimits({cpu: this.resources.cpu.limit, memory: this.resources.memory.limit})
+        + container.livenessProbe.withPeriodSeconds(60)
+        + container.livenessProbe.httpGet.withPath('/health')
+        + container.livenessProbe.httpGet.withPort(this.ports.internal)
+        + container.readinessProbe.httpGet.withPath('/health')
+        + container.readinessProbe.httpGet.withPort(this.ports.internal)
+        + container.startupProbe.httpGet.withPath('/health')
+        + container.startupProbe.httpGet.withPort(this.ports.internal)
+        + container.startupProbe.withFailureThreshold(30)
+        + container.startupProbe.withPeriodSeconds(10),
+      daemonSet: daemonSet.new(name = this.name, containers = [this.deployables.container])
+        + daemonSet.metadata.withAnnotations(this.annotations.deployment)
+        + daemonSet.metadata.withLabels(this.labels.deployment)
+        + daemonSet.spec.selector.withMatchLabels(this.labels.selector)
+        + daemonSet.spec.template.metadata.withAnnotations(this.annotations.pod)
+        + daemonSet.spec.template.metadata.withLabels(this.labels.pod + this.labels.selector)
+        + daemonSet.spec.template.spec.withServiceAccount(this.name)
+        + daemonSet.spec.template.spec.withTerminationGracePeriodSeconds(60)
+        + daemonSet.spec.template.spec.withTolerations([
+          toleration.withOperator('Exists') + toleration.withEffect('NoSchedule'),
+        ])
+        + daemonSet.spec.template.spec.withVolumes([
+          volume.fromConfigMap('config', this.name),
+          volume.fromHostPath('data-dir', '/var/lib/vector'),
+          volume.fromHostPath('procfs', '/proc'),
+          volume.fromHostPath('sysfs', '/sys'),
+          volume.fromHostPath('var-lib', '/var/lib'),
+          volume.fromHostPath('var-log', '/var/log'),
+          volume.fromSecret('service-account-token', 'vector-service-account-token'),
+        ]),
+    },
   },
 }

--- a/vector/deployment/kubernetes/rbac.libsonnet
+++ b/vector/deployment/kubernetes/rbac.libsonnet
@@ -10,25 +10,27 @@ local tk = import 'tk';
 
   vector+: {
     local this = self,
-    clusterRole: clusterRole.new(this.name)
-      + clusterRole.metadata.withLabels(this.labels.selector)
-      + clusterRole.withRules([
-        resourceRule.withApiGroups('')
-        + resourceRule.withResources(['pods', 'namespaces', 'nodes', 'nodes/proxy'])
-        + resourceRule.withVerbs(['get', 'list', 'watch']),
-      ]),
-    clusterRoleBinding: clusterRoleBinding.new(this.name)
-      + clusterRoleBinding.metadata.withLabels(this.labels.selector)
-      + clusterRoleBinding.roleRef.withName(this.name)
-      + clusterRoleBinding.roleRef.withKind('ClusterRole')
-      + clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io')
-      + clusterRoleBinding.withSubjects(
-        subject.withName(this.name)
-        + subject.withKind('ServiceAccount')
-        + subject.withNamespace(tk.env.spec.namespace),
-      ),
-    serviceAccount: serviceAccount.new(this.name)
-      + serviceAccount.metadata.withLabels(this.labels.selector)
-      + serviceAccount.withAutomountServiceAccountToken(false),
+    deployables+: {
+      clusterRole: clusterRole.new(this.name)
+        + clusterRole.metadata.withLabels(this.labels.selector)
+        + clusterRole.withRules([
+          resourceRule.withApiGroups('')
+          + resourceRule.withResources(['pods', 'namespaces', 'nodes', 'nodes/proxy'])
+          + resourceRule.withVerbs(['get', 'list', 'watch']),
+        ]),
+      clusterRoleBinding: clusterRoleBinding.new(this.name)
+        + clusterRoleBinding.metadata.withLabels(this.labels.selector)
+        + clusterRoleBinding.roleRef.withName(this.name)
+        + clusterRoleBinding.roleRef.withKind('ClusterRole')
+        + clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io')
+        + clusterRoleBinding.withSubjects(
+          subject.withName(this.name)
+          + subject.withKind('ServiceAccount')
+          + subject.withNamespace(tk.env.spec.namespace),
+        ),
+      serviceAccount: serviceAccount.new(this.name)
+        + serviceAccount.metadata.withLabels(this.labels.selector)
+        + serviceAccount.withAutomountServiceAccountToken(false),
+    },
   },
 }

--- a/vector/deployment/kubernetes/secret.libsonnet
+++ b/vector/deployment/kubernetes/secret.libsonnet
@@ -4,14 +4,16 @@
 
   vector+: {
     local this = self,
-    secret+: {
-      influxDBToken: secret.new('vector-influx-db-token', {
-        token: std.base64($.influxDB.secrets.token),
-      })
-      + secret.metadata.withLabels(this.labels.selector),
-      serviceAccountToken: secret.new('vector-service-account-token', {}, 'kubernetes.io/service-account-token')
-      + secret.metadata.withAnnotations({'kubernetes.io/service-account.name': this.name})
-      + secret.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      secrets: {
+        influxDBToken: secret.new('vector-influx-db-token', {
+          token: std.base64($.influxDB.secrets.token),
+        })
+        + secret.metadata.withLabels(this.labels.selector),
+        serviceAccountToken: secret.new('vector-service-account-token', {}, 'kubernetes.io/service-account-token')
+        + secret.metadata.withAnnotations({'kubernetes.io/service-account.name': this.name})
+        + secret.metadata.withLabels(this.labels.selector),
+      },
     },
   },
 }

--- a/vector/deployment/kubernetes/service.libsonnet
+++ b/vector/deployment/kubernetes/service.libsonnet
@@ -5,11 +5,13 @@
 
   vector+: {
     local this = self,
-    service: service.new(
-      this.name,
-      this.labels.selector,
-      [servicePort.newNamed('http', this.ports.external, this.ports.internal)],
-    )
-      + service.metadata.withLabels(this.labels.selector),
+    deployables+: {
+      service: service.new(
+        this.name,
+        this.labels.selector,
+        [servicePort.newNamed('http', this.ports.external, this.ports.internal)],
+      )
+        + service.metadata.withLabels(this.labels.selector),
+    },
   },
 }


### PR DESCRIPTION
This prevents accidental overrides coming from the config.jsonnet.  
Since all deployments are stored under "deployables", which does not overlap with any config.

Resolves #37 